### PR TITLE
refactor: use EventEmitter API to emit events for replay blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Uses the excellent https://github.com/keichi/binary-parser to parse the replay f
 
 This parser is aimed to be more modular than other parsers.
 You can easily add your custom action parsing logic by overriding the processTimeSlot() function
-of a W3GReplay instance.
+of a W3GReplay instance or by listening for one of the five main events:
+
+
 
 **It does not fully support replays of game version <= 1.14.**
 
@@ -18,10 +20,31 @@ of a W3GReplay instance.
 ```
 
 ## Usage
+
+### High Level API
+
 ```javascript
   const W3GReplay = require('w3gjs')
   const Parser = new W3GReplay()
   const replay = Parser.parse('./replays/sample1.w3g')
+  console.log(replay)
+```
+
+### Low Level API
+Low level API allows you to either implement your own logic on top of the ReplayParser class by extending it or 
+to listen for its callbacks for specific events.
+
+```javascript
+const W3GReplay = require('w3gjs')
+const Parser = new W3GReplay()
+
+Parser.on('gamemetadata', (metadata) => console.log(metadata))
+Parser.on('gamedatablock', (block) => console.log('game data block.'))
+Parser.on('timeslotblock', (block) => console.log('time slot block.', Parser.msElapsed))
+Parser.on('commandblock', (block) => console.log('command block.'))
+Parser.on('actionblock', (block) => console.log('action block.'))
+
+Parser.parse('./replays/999.w3g')
 ```
 
 ### Example output of the observers.w3g example replay

--- a/example.js
+++ b/example.js
@@ -12,9 +12,28 @@ function formatBytes (bytes, decimals) {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 }
 
+/*
+
+Chronological order of Blocks when calling EventEmitters callbacks is guaranteed.
+
+You can decide how to proceed and what kind of blocks you want to know about.
+Check the W3GReplay.ts file for a reference on how to listen to the callbacks.
+
+If you need to track the current time, access W3GParser.msElapsed property which keeps track of
+the time elapsed while parsing the replay file.
+
+W3GParser.on('gamedatablock', (block) => console.log('game data block.'))
+W3GParser.on('timeslotblock', (block) => console.log('time slot block.', W3GParser.msElapsed))
+W3GParser.on('commandblock', (block) => console.log('command block.'))
+W3GParser.on('actionblock', (block) => console.log('action block.'))
+
+*/
+
 replays.forEach((replayFile) => {
   const parseResult = W3GParser.parse(`./replays/${replayFile}`)
-  console.log(parseResult.version)
+  // console.log(parseResult)
+  console.log(replayFile)
   console.log(replayFile, formatBytes(Buffer.byteLength(JSON.stringify(parseResult), 'utf8')))
   console.log('=====')
+  // process.exit()
 })

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -226,7 +226,7 @@ class Player {
     this._currentlyTrackedAPM ++
   }
 
-  handle0x16(selectMode: any, isAPM: any) {
+  handle0x16(selectMode: number, isAPM: boolean) {
     if (isAPM) {
       this.actions['select'] = this.actions['select'] + 1 || 1
       this._currentlyTrackedAPM ++

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -58,6 +58,7 @@ class Player {
     esc: number
   }
   _currentlyTrackedAPM: number
+  _lastActionWasDeselect: boolean
   currentTimePlayed: number
   apm: number
 
@@ -90,6 +91,7 @@ class Player {
       esc: 0
     }
     this._currentlyTrackedAPM = 0
+    this._lastActionWasDeselect = false
     this.currentTimePlayed = 0
     this.apm = 0
     return this

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -10,6 +10,13 @@ const isObjectId = (input: string) => ['u', 'e', 'h', 'o'].includes(input[0])
 const isRightclickAction = (input: number[]) => input[0] === 0x03 && input[1] === 0
 const isBasicAction = (input: number[]) => input[0] <= 0x19 && input[1] === 0
 
+interface heroInfo {
+    level: number,
+    abilities: { [key: string]: number },
+    order: number,
+    id: string
+}
+
 class Player {
   id: number
   name: string
@@ -33,14 +40,8 @@ class Player {
     summary: { [key: string]: number },
     order: { id: string, ms: number }[]
   }
-  heroes: {
-    [key: string]: {
-      level: number,
-      abilities: { [key: string]: number },
-      order: number,
-      id: string
-    }
-  }
+  heroes:heroInfo[]
+  heroCollector: {[key: string]: heroInfo}
   heroSkills: { [key: string]: number }
   heroCount: number
   actions: {
@@ -73,7 +74,8 @@ class Player {
     this.upgrades = { summary: {}, order: [] }
     this.items = { summary: {}, order: [] }
     this.buildings = { summary: {}, order: [] }
-    this.heroes = {}
+    this.heroes = []
+    this.heroCollector = {}
     this.heroSkills = {}
     this.heroCount = 0
     this.actions = {
@@ -136,13 +138,13 @@ class Player {
   }
 
   handleHeroSkill(actionId: string): void {
-    if (this.heroes[abilityToHero[actionId]] === undefined) {
+    if (this.heroCollector[abilityToHero[actionId]] === undefined) {
       this.heroCount += 1
-      this.heroes[abilityToHero[actionId]] = { level: 0, abilities: {}, order: this.heroCount, id: abilityToHero[actionId] }
+      this.heroCollector[abilityToHero[actionId]] = { level: 0, abilities: {}, order: this.heroCount, id: abilityToHero[actionId] }
     }
-    this.heroes[abilityToHero[actionId]].level += 1
-    this.heroes[abilityToHero[actionId]].abilities[actionId] = this.heroes[abilityToHero[actionId]].abilities[actionId] || 0
-    this.heroes[abilityToHero[actionId]].abilities[actionId] += 1
+    this.heroCollector[abilityToHero[actionId]].level += 1
+    this.heroCollector[abilityToHero[actionId]].abilities[actionId] = this.heroCollector[abilityToHero[actionId]].abilities[actionId] || 0
+    this.heroCollector[abilityToHero[actionId]].abilities[actionId] += 1
   }
 
   handle0x10(actionId: string, gametime: number): void {
@@ -261,13 +263,11 @@ class Player {
   cleanup(): void {
     const apmSum = this.actions.timed.reduce((a: number, b: number): number => a + b)
     this.apm = Math.round(apmSum / this.actions.timed.length)
-    // @ts-ignore
-    this.heroes = Object.values(this.heroes).sort((h1, h2) => h1.order - h2.order).reduce((aggregator, hero) => {
+    this.heroes = Object.values(this.heroCollector).sort((h1, h2) => h1.order - h2.order).reduce((aggregator, hero) => {
       delete hero['order']
-      // @ts-ignore
       aggregator.push(hero)
       return aggregator
-    }, [])
+    }, <heroInfo[]>[])
 
     delete this._currentlyTrackedAPM
   }

--- a/src/ReplayParser.ts
+++ b/src/ReplayParser.ts
@@ -46,7 +46,6 @@ class ReplayParser extends EventEmitter{
     })
     this.decompressed = Buffer.concat(decompressed)
 
-    // @ts-ignore
     this.gameMetaDataDecoded = GameDataParserComposed.parse(this.decompressed)
     const decodedMetaStringBuffer = this.decodeGameMetaString(this.gameMetaDataDecoded.meta.encodedString)
     const meta = { ...this.gameMetaDataDecoded, ...this.gameMetaDataDecoded.meta, ...EncodedMapMetaString.parse(decodedMetaStringBuffer) }

--- a/src/ReplayParser.ts
+++ b/src/ReplayParser.ts
@@ -1,0 +1,144 @@
+import { Parser } from 'binary-parser'
+import { ActionBlockList } from './parsers/actions'
+import { ReplayHeader, EncodedMapMetaString, GameMetaData } from './parsers/header'
+import { GameDataParser } from './parsers/gamedata'
+
+// Cannot import node modules directly because error with rollup
+// https://rollupjs.org/guide/en#error-name-is-not-exported-by-module-
+const { readFileSync, appendFileSync } = require('fs')
+const { inflateSync, constants } = require('zlib')
+const { createHash } = require('crypto')
+const GameDataParserComposed = new Parser()
+  .nest('meta', { type: GameMetaData })
+  .nest('blocks', { type: GameDataParser })
+const EventEmitter = require('events')
+
+class ReplayParser extends EventEmitter{
+  filename: string
+  buffer: Buffer
+  id: string
+  header: {
+    magic: string
+    offset: number
+    compressedSize: number
+    headerVersion: string
+    decompressedSize: number
+    compressedDataBlockCount: number
+    gameIdentifier: string
+    version: number
+    buildNo: number
+    flags: string
+    replayLengthMS: number
+    checksum: number
+    blocks: {
+      blockSize: number
+      blockDecompressedSize: number
+      unknown: string
+      compressed: Buffer
+    }[]
+  }
+  }
+
+  constructor() {
+    super()
+    this.buffer = Buffer.from('')
+    this.filename= ''
+  }
+
+  parse($buffer: string): W3GReplay['final'] {
+    console.time('parse')
+    this.buffer = readFileSync($buffer)
+    this.buffer = this.buffer.slice(this.buffer.indexOf('Warcraft III recorded game'))
+    this.filename = $buffer
+    this.parseHeader(this.buffer)
+    const decompressed: Buffer[] = []
+    this.header.blocks.forEach(block => {
+      if (block.blockSize > 0 && block.blockDecompressedSize === 8192) {
+        try {
+          const r = inflateSync(block.compressed, { finishFlush: constants.Z_SYNC_FLUSH })
+          if (r.byteLength > 0 && block.compressed.byteLength > 0) {
+            decompressed.push(r)
+          }
+        } catch (ex) {
+          console.log(ex)
+        }
+      }
+    })
+    this.decompressed = Buffer.concat(decompressed)
+
+    // @ts-ignore
+    this.gameMetaDataDecoded = GameDataParserComposed.parse(this.decompressed)
+
+    const decodedMetaStringBuffer = this.decodeGameMetaString(this.gameMetaDataDecoded.meta.encodedString)
+    this.meta = { ...this.gameMetaDataDecoded, ...EncodedMapMetaString.parse(decodedMetaStringBuffer) }
+
+    this.slots = this.gameMetaDataDecoded.meta.playerSlotRecords
+    this.playerList = [this.gameMetaDataDecoded.meta.player, ...this.gameMetaDataDecoded.meta.playerList]
+
+    console.timeEnd('parse')
+    return this.finalize()
+  }
+
+  parseHeader(){
+    this.header = ReplayHeader.parse(this.buffer)
+  }
+
+  parseGameDataBlock(){
+    this.gameMetaDataDecoded.blocks.forEach((block: any) => {
+        this.emit('gamedatablock', block)
+        this.processGameDataBlock(block)
+    })
+  }
+
+  processGameDataBlock(block) {
+      switch (block.type) {
+        case 31:
+        case 30:
+          this.emit('timeslotblock', block)
+          break
+      }
+    })
+  }
+
+  processTimeSlot(timeSlotBlock: any): void {
+    this.emit('timeslot', timeSlotBlock)
+    timeSlotBlock.actions.forEach((actionBlock: any): void => {
+      this.processCommandDataBlock(actionBlock)
+      this.emit('commandblock', actionBlock)
+    })
+  }
+
+  processCommandDataBlock(actionBlock: any) {
+    const currentPlayer = this.players[actionBlock.playerId]
+    currentPlayer.currentTimePlayed = this.totalTimeTracker
+    currentPlayer._lastActionWasDeselect = false
+    try {
+      ActionBlockList.parse(actionBlock.actions).forEach((action: any): void => {
+        this.emit('actionblock', action, currentPlayer)
+      })
+    } catch (ex) {
+      console.error(ex)
+    }
+  }
+
+  decodeGameMetaString(str: string): Buffer {
+    let test = Buffer.from(str, 'hex')
+    let decoded = Buffer.alloc(test.length)
+    let mask = 0
+    let dpos = 0
+
+    for (let i = 0; i < test.length; i++) {
+      if (i % 8 === 0) {
+        mask = test[i]
+      } else {
+        if ((mask & (0x1 << (i % 8))) === 0) {
+          decoded.writeUInt8(test[i] - 1, dpos++)
+        } else {
+          decoded.writeUInt8(test[i], dpos++)
+        }
+      }
+    }
+    return decoded
+}
+
+export default W3GReplay

--- a/src/ReplayParser.ts
+++ b/src/ReplayParser.ts
@@ -23,7 +23,8 @@ const EventEmitter = require('events')
 class ReplayParser extends EventEmitter{
   filename: string
   buffer: Buffer
-
+  msElapsed: number = 0
+  
   constructor() {
     super()
     this.buffer = Buffer.from('')
@@ -78,6 +79,7 @@ class ReplayParser extends EventEmitter{
       switch (block.type) {
         case 31:
         case 30:
+          this.msElapsed += block.timeIncrement
           this.emit('timeslotblock', <TimeSlotBlock> <unknown> block)
           this._processTimeSlot( <TimeSlotBlock> <unknown> block)
           break

--- a/src/parsers/gamedata.ts
+++ b/src/parsers/gamedata.ts
@@ -52,7 +52,7 @@ const PlayerChatMessageBlock = new Parser()
       choices: {
         0x10: new Parser(),
         // @ts-ignore
-        0x20: new Parser().int8('chatMode', { length: 4, formatter: chatModeFormatter, encoding: 'hex' }).skip(3)
+        0x20: new Parser().int8('mode', { length: 4, formatter: chatModeFormatter, encoding: 'hex' }).skip(3)
       }
     }
   )

--- a/src/parsers/header.ts
+++ b/src/parsers/header.ts
@@ -151,5 +151,6 @@ const EncodedMapMetaString = new Parser()
 export {
   ReplayHeader,
   EncodedMapMetaString,
-  GameMetaData
+  GameMetaData,
+  DataBlock
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,18 @@ export enum Races {
   orcs = 'O',
   undeads = 'U'
 }
+
+export interface SlotRecord {
+    playerId: number
+    slotStatus: number
+    computerFlag: number
+    teamId: number
+    color: number
+    raceFlag: Races
+    aiStrength: number
+    handicapFlag: number 
+  }
+
 export interface GameMetaDataDecoded {
     player: {
       hasRecord?: number
@@ -27,16 +39,7 @@ export interface GameMetaDataDecoded {
     gameStartRecord: number
     dataByteCount: number
     slotRecordCount: number
-    playerSlotRecords: {
-      playerId: number
-      slotStatus: number
-      computerFlag: number
-      teamId: number
-      color: number
-      raceFlag: Races
-      aiStrength: number
-      handicapFlag: number 
-    }[]
+    playerSlotRecords: SlotRecord[]
     randomSeed: number
     selectMode: string
     startSpotCount: number,
@@ -57,6 +60,11 @@ export interface GameMetaDataDecoded {
     mapName: string,
     creator: string   
   }
+
+export interface ActionBlock{
+  actionId: number
+  [key: string]: any
+}
 
 export interface TimeSlotBlock {
   byteCount: number
@@ -87,6 +95,13 @@ export interface Unknown0x22{
   length: number
 }
 
+export interface CompressedDataBlock {
+  blockSize: number
+  blockDecompressedSize: number
+  unknown: string
+  compressed: Buffer
+}
+
 export interface CommandDataBlock {
   playerId: number,
   blockLength: number,
@@ -95,6 +110,7 @@ export interface CommandDataBlock {
 
 export interface GameDataBlock {
   type: number
+  [key: string]: any
 }
 
 export interface ParserOutput {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,134 @@
+import Player from './Player'
+
 export enum Races {
   humans = 'H',
   nightElves = 'N',
   orcs = 'O',
   undeads = 'U'
+}
+export interface GameMetaDataDecoded {
+    player: {
+      hasRecord?: number
+      playerId: number
+      playerName: string
+      addDataFlag?: number
+      addDataFlagHost?: number
+      additional: {
+        runtimeMs?: string
+        raceFlags?: Races
+      }
+    }
+    gameName: string
+    encodedString: string
+    playerCount: number
+    gameType: string
+    languageId: string
+    playerList: GameMetaDataDecoded['player'][]
+    gameStartRecord: number
+    dataByteCount: number
+    slotRecordCount: number
+    playerSlotRecords: {
+      playerId: number
+      slotStatus: number
+      computerFlag: number
+      teamId: number
+      color: number
+      raceFlag: Races
+      aiStrength: number
+      handicapFlag: number 
+    }[]
+    randomSeed: number
+    selectMode: string
+    startSpotCount: number,
+    speed: number,
+    hideTerrain: number,
+    mapExplored: number,
+    alwaysVisible: number,
+    default: number,
+    observerMode: number,
+    teamsTogether: number,
+    empty: number,
+    fixedTeams: number,
+    fullSharedUnitControl: number,
+    randomHero: number,
+    randomRaces: number,
+    referees : number,
+    mapChecksum: string,
+    mapName: string,
+    creator: string   
+  }
+
+export interface TimeSlotBlock {
+  byteCount: number
+  timeIncrement: number
+  actions : any[]
+}
+
+export interface LeaveGameBlock{
+  reason: string,
+  playerId: number,
+  result: string
+}
+
+export interface TimeSlotBlock0x1f{
+  byteCount: number,
+  timeIncrement: number,
+  actions: any[]
+}
+
+export interface PlayerChatMessageBlock{
+  playerId: number,
+  byteCount: number,
+  flags: number,
+  chatMode ? : number
+}
+
+export interface Unknown0x22{
+  length: number
+}
+
+export interface CommandDataBlock {
+  playerId: number,
+  blockLength: number,
+  actions: Buffer
+}
+
+export interface GameDataBlock {
+  type: number
+}
+
+export interface ParserOutput {
+  id: string
+  gamename: GameMetaDataDecoded['gameName']
+  randomseed: GameMetaDataDecoded['randomSeed']
+  startSpots: GameMetaDataDecoded['startSpotCount']
+  observers: string[]
+  players: Player[]
+  matchup: string
+  creator: GameMetaDataDecoded['creator']
+  type: string
+  chat: any[]
+  apm: {
+    trackingInterval: number
+  }
+  map: {
+    path: GameMetaDataDecoded['mapName']
+    file: string
+    checksum: GameMetaDataDecoded['mapChecksum']
+  }
+  version: string
+  duration: number
+  expansion: boolean
+  settings: {
+    referees: boolean
+    fixedTeams: boolean
+    fullSharedUnitControl: boolean
+    alwaysVisible: boolean
+    hideTerrain: boolean
+    mapExplored: boolean
+    teamsTogether: boolean
+    randomHero: boolean
+    randomRaces: boolean
+    speed: GameMetaDataDecoded['speed']
+  }
 }

--- a/test/replays.test.ts
+++ b/test/replays.test.ts
@@ -17,6 +17,7 @@ describe('Replay parsing tests', () => {
     expect(test.players[0].id).toBe(6)
     expect(test.players[0].teamid).toBe(0)
     expect(test.observers.length).toBe(4)
+    expect(test.chat.length).toBeGreaterThan(2)
     expect(test.matchup).toBe('OvO')
     expect(test.type).toBe('1on1')
     expect(test.players.length).toBe(2)


### PR DESCRIPTION
This PR aims to provide better output customization for parser users. It allows to listen for events for any kind of block that exists in the replay hierarchy. In addition, it decouples the basic parser logic in a separate file so that overall complexity of the W3GReplay class is reduced.


- [x] finish refactoring parser logic into separate file
- [x] correct the currently disabled typings 
- [x] refactor typings to be less clustered
- [x] update documentation and example
